### PR TITLE
docs(routing): add issue #2 traceability

### DIFF
--- a/docs/traceability/issue-2-routing.md
+++ b/docs/traceability/issue-2-routing.md
@@ -1,0 +1,26 @@
+# Issue #2 Traceability — Routing Foundation
+
+This document provides traceability for issue #2:
+`feat(routing): add core pages and route definitions`.
+
+## Status
+
+Already implemented on branch `tp` before this issue execution window.
+
+## Evidence
+
+- Router configuration exists in `src/Router/index.tsx`
+  - `/` → `Home`
+  - `/movies` → `Movies`
+  - `/movies/:movieId` → `Movie`
+  - `*` → `NotFound`
+- Required pages exist and are wired:
+  - `src/pages/Home/index.tsx`
+  - `src/pages/Movies/index.tsx`
+  - `src/pages/Movie/index.tsx`
+  - `src/pages/NotFound/index.tsx`
+
+## Scope note
+
+No runtime code change was required for this issue.
+This PR is intentionally minimal and for project traceability only.

--- a/docs/traceability/issue-2-routing.md
+++ b/docs/traceability/issue-2-routing.md
@@ -10,10 +10,12 @@ Already implemented on branch `tp` before this issue execution window.
 ## Evidence
 
 - Router configuration exists in `src/Router/index.tsx`
-  - `/` → `Home`
-  - `/movies` → `Movies`
-  - `/movies/:movieId` → `Movie`
-  - `*` → `NotFound`
+  - `/` (parent route)
+    - index / `path: ""` → `Home`
+    - `path: "movies"` (`/movies`) → `Movies`
+    - `path: "movies/:movieId"` (`/movies/:movieId`) → `Movie`
+    - `path: "*"` → `NotFound`
+- Router is mounted in `src/App.tsx` via `<Router />`
 - Required pages exist and are wired:
   - `src/pages/Home/index.tsx`
   - `src/pages/Movies/index.tsx`


### PR DESCRIPTION
## Summary
- add a traceability note for issue #2 in `docs/traceability/issue-2-routing.md`
- document evidence that routing/pages are already implemented on `tp`

## Why
Issue #2 is already satisfied in the current `tp` baseline.
Per agreed workflow, this PR provides minimal traceability without unnecessary code changes.

## Scope policy
- MUST HAVE only
- no runtime changes

Closes #2
