### PR TITLE
docs(layout): add issue #3 traceability

### DIFF
--- a/docs/traceability/issue-3-layout-template.md
+++ b/docs/traceability/issue-3-layout-template.md
@@ -1,0 +1,23 @@
+# Issue #3 Traceability — Default Page Template
+
+This document provides traceability for issue #3:
+`feat(layout): implement default page template with outlet`.
+
+## Status
+
+Already implemented on branch `tp` before this issue execution window.
+
+## Evidence
+
+- Default template component exists in `src/pages/PageTemplate/index.tsx`
+- Layout structure includes:
+  - `<header>` with `<Header />`
+  - `<main>` with `<Outlet />`
+  - `<footer>` with `<Footer />`
+- Template styling exists in `src/pages/PageTemplate/classes.module.css`
+- Router uses the template as parent route element in `src/Router/index.tsx`
+
+## Scope note
+
+No runtime code change was required for this issue.
+This PR is intentionally minimal and for project traceability only.


### PR DESCRIPTION
## Summary
- add a traceability note for issue #3 in `docs/traceability/issue-3-layout-template.md`
- document evidence that the default page template is already implemented on `tp`

## Why
Issue #3 is already satisfied in the current `tp` baseline.
Per agreed workflow, this PR provides minimal traceability without unnecessary runtime changes.

## Scope policy
- MUST HAVE only
- no runtime changes

Closes #3
