### PR TITLE
docs(header): add issue #4 traceability

### DIFF
--- a/docs/traceability/issue-4-header-navbar.md
+++ b/docs/traceability/issue-4-header-navbar.md
@@ -1,0 +1,27 @@
+# Issue #4 Traceability — Header and Navigation Bar
+
+This document provides traceability for issue #4:
+`feat(header): implement navbar with active-tab navigation`.
+
+## Status
+
+Already implemented on branch `tp` before this issue execution window.
+
+## Evidence
+
+- Header component includes:
+  - main title (`<Typography component="h1" ...>`) in `src/components/Header/index.tsx`
+  - description text in `src/components/Header/index.tsx`
+  - embedded `<NavBar />` in `src/components/Header/index.tsx`
+- NavBar component implementation exists in `src/components/Header/NavBar/index.tsx`
+- Active-tab logic is implemented using `useMatch`:
+  - `useMatch("/")` for Home
+  - `useMatch("/movies/*")` for Movies and nested routes
+- Navigation actions are implemented with `useNavigate`:
+  - navigate to `/`
+  - navigate to `/movies`
+
+## Scope note
+
+No runtime code change was required for this issue.
+This PR is intentionally minimal and for project traceability only.


### PR DESCRIPTION
## Summary
- add a traceability note for issue #4 in `docs/traceability/issue-4-header-navbar.md`
- document evidence that Header + NavBar active navigation are already implemented on `tp`

## Why
Issue #4 is already satisfied in the current `tp` baseline.
Per agreed workflow, this PR provides minimal traceability without unnecessary runtime changes.

## Scope policy
- MUST HAVE only
- no runtime changes

Closes #4
