### PR TITLE
docs(i18n): add issue #5 traceability

### DIFF
--- a/docs/traceability/issue-5-i18n-bootstrap.md
+++ b/docs/traceability/issue-5-i18n-bootstrap.md
@@ -1,0 +1,20 @@
+# Issue #5 Traceability — i18n Bootstrap
+
+This document provides traceability for issue #5:
+`feat(i18n): bootstrap i18next in application entrypoint`.
+
+## Status
+
+Already implemented on branch `tp` before this issue execution window.
+
+## Evidence
+
+- i18n bootstrap file exists in `src/i18n/index.ts`
+- i18next is configured with resources and default/fallback language in `src/i18n/index.ts`
+- i18n initialization is imported at app startup in `src/index.tsx`:
+  - `import "./i18n";`
+
+## Scope note
+
+No runtime code change was required for this issue.
+This PR is intentionally minimal and for project traceability only.


### PR DESCRIPTION
## Summary
- add a traceability note for issue #5 in `docs/traceability/issue-5-i18n-bootstrap.md`
- document evidence that i18n bootstrap is already implemented on `tp`

## Why
Issue #5 is already satisfied in the current `tp` baseline.
Per agreed workflow, this PR provides minimal traceability without unnecessary runtime changes.

## Scope policy
- MUST HAVE only
- no runtime changes

Closes #5
