### PR TITLE
docs(i18n): add issue #6 traceability

### DIFF
--- a/docs/traceability/issue-6-i18n-dictionaries-map.md
+++ b/docs/traceability/issue-6-i18n-dictionaries-map.md
@@ -1,0 +1,21 @@
+# Issue #6 Traceability — i18n Dictionaries and Typed Map
+
+This document provides traceability for issue #6:
+`feat(i18n): add EN/FR dictionaries and typed i18n map`.
+
+## Status
+
+Already implemented on branch `tp` before this issue execution window.
+
+## Evidence
+
+- English dictionary exists in `src/i18n/dictionnaries/en.ts`
+- French dictionary exists in `src/i18n/dictionnaries/fr.ts`
+- Typed i18n key map exists in `src/i18n/map.ts`
+  - recursive map builder (`buildI18nMap`)
+  - exported typed keys object: `i18nMap`
+
+## Scope note
+
+No runtime code change was required for this issue.
+This PR is intentionally minimal and for project traceability only.


### PR DESCRIPTION
## Summary
- add a traceability note for issue #6 in `docs/traceability/issue-6-i18n-dictionaries-map.md`
- document evidence that EN/FR dictionaries and typed i18n map are already implemented on `tp`

## Why
Issue #6 is already satisfied in the current `tp` baseline.
Per agreed workflow, this PR provides minimal traceability without unnecessary runtime changes.

## Scope policy
- MUST HAVE only
- no runtime changes

Closes #6
