### PR TITLE
docs(header): add issue #7 traceability

### DIFF
--- a/docs/traceability/issue-7-header-language-selector.md
+++ b/docs/traceability/issue-7-header-language-selector.md
@@ -1,0 +1,25 @@
+# Issue #7 Traceability — Header Language Selector and Translations
+
+This document provides traceability for issue #7:
+`feat(header): add language selector and translate header/navbar`.
+
+## Status
+
+Already implemented on branch `tp` before this issue execution window.
+
+## Evidence
+
+- Language selector component exists in:
+  - `src/components/Header/LanguageSelector/index.tsx`
+  - `src/components/Header/LanguageSelector/classes.module.css`
+- Selector updates current language through `i18n.changeLanguage(...)`
+- Header uses translations via `useTranslation()` and `i18nMap` keys:
+  - title (`i18nMap.header.title`)
+  - description (`i18nMap.header.description`)
+- Header embeds `<LanguageSelector />`
+- NavBar labels are translated from dictionary keys (`i18nMap.header.nav.*`)
+
+## Scope note
+
+No runtime code change was required for this issue.
+This PR is intentionally minimal and for project traceability only.


### PR DESCRIPTION
## Summary
- add a traceability note for issue #7 in `docs/traceability/issue-7-header-language-selector.md`
- document evidence that Header language selector and related translations are already implemented on `tp`

## Why
Issue #7 is already satisfied in the current `tp` baseline.
Per agreed workflow, this PR provides minimal traceability without unnecessary runtime changes.

## Scope policy
- MUST HAVE only
- no runtime changes

Closes #7
